### PR TITLE
Enhancements to allow configuration of header name and key_id

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -140,14 +140,22 @@ local function build_payload_hash()
   return str.to_hex(payload_digest)
 end
 
---- Add the JWT header to the reqeust
+local function build_header_value(conf, jwt)
+  if (conf.include_credential_type == true) then
+    return "Bearer " .. jwt
+  else
+    return jwt
+  end
+end
+
+--- Add the JWT header to the request
 -- @param conf the configuration
 local function add_jwt_header(conf)
   local payload_hash = build_payload_hash()
   local payload = build_jwt_payload(conf, payload_hash)
   local kong_private_key = get_kong_key("pkey", get_private_key_location(conf))
   local jwt = encode_jwt_token(conf, payload, kong_private_key)
-  ngx.req.set_header("JWT", jwt)
+  ngx.req.set_header(conf.header, build_header_value(conf, jwt))
 end
 
 --- Execute the script

--- a/src/access.lua
+++ b/src/access.lua
@@ -83,6 +83,9 @@ local function encode_jwt_token(conf, payload, key)
       b64_encode(get_kong_key("pubder", get_public_key_location(conf)))
     }
   }
+  if (conf.key_id) then
+    header.kid = conf.key_id
+  end
   local segments = {
     b64_encode(json.encode(header)),
     b64_encode(json.encode(payload))

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -4,6 +4,7 @@ return {
   fields = {
     issuer = { type = "string", required = false },
     private_key_location = { type = "string", required = false },
-    public_key_location = { type = "string", required = false }
+    public_key_location = { type = "string", required = false },
+    key_id = { type = "string", required = false}
   }
 }

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -5,6 +5,8 @@ return {
     issuer = { type = "string", required = false },
     private_key_location = { type = "string", required = false },
     public_key_location = { type = "string", required = false },
-    key_id = { type = "string", required = false}
+    key_id = { type = "string", required = false},
+    header = { type = "string", default = "JWT"},
+    include_credential_type = { type = "boolean", default = false}
   }
 }


### PR DESCRIPTION
#5 - Adding two optional new config parameters:
`header` to allow the user to specify the name of the header key that should store the JWT token
`include_credential_type` to have the option of including the credential type in the header value - (defaulted to `Bearer` since we are only working with JWT tokens)

#6 - Adding new optional config parameter `key_id` to allow setting of the header kid claim