### PR TITLE
Enhancements to allow configuration of header name and key_id

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -83,7 +83,7 @@ local function encode_jwt_token(conf, payload, key)
       b64_encode(get_kong_key("pubder", get_public_key_location(conf)))
     }
   }
-  if (conf.key_id) then
+  if conf.key_id then
     header.kid = conf.key_id
   end
   local segments = {
@@ -141,7 +141,7 @@ local function build_payload_hash()
 end
 
 local function build_header_value(conf, jwt)
-  if (conf.include_credential_type == true) then
+  if conf.include_credential_type then
     return "Bearer " .. jwt
   else
     return jwt

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -4,6 +4,9 @@ return {
   fields = {
     issuer = { type = "string", required = false },
     private_key_location = { type = "string", required = false },
-    public_key_location = { type = "string", required = false }
+    public_key_location = { type = "string", required = false },
+    key_id = { type = "string", required = false},
+    header = { type = "string", default = "JWT"},
+    include_credential_type = { type = "boolean", default = false}
   }
 }


### PR DESCRIPTION
#5 - Adding two optional new config parameters:
header to allow the user to specify the name of the header key that should store the JWT token
include_credential_type to have the option of including the credential type in the header value - (defaulted to Bearer since we are only working with JWT tokens)

#6 - Adding new optional config parameter key_id to allow setting of the header kid claim